### PR TITLE
Implement order creation method with service layer

### DIFF
--- a/src/main/java/ru/dadaev/OrderService/controller/OrderController.java
+++ b/src/main/java/ru/dadaev/OrderService/controller/OrderController.java
@@ -8,15 +8,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ru.dadaev.OrderService.dto.OrderRequestDto;
 import ru.dadaev.OrderService.dto.OrderResponseDto;
+import ru.dadaev.OrderService.service.OrderService;
 
 @RestController
 @RequestMapping("/orders")
 @Tag(name = "Orders", description = "Operations about chicken orders")
 public class OrderController {
 
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
     @PostMapping
     @Operation(summary = "Create new order")
     public OrderResponseDto createOrder(@RequestBody OrderRequestDto request) {
-        return new OrderResponseDto("accepted", request.getId());
+        return orderService.createOrder(request);
     }
 }

--- a/src/main/java/ru/dadaev/OrderService/domain/Order.java
+++ b/src/main/java/ru/dadaev/OrderService/domain/Order.java
@@ -1,0 +1,23 @@
+package ru.dadaev.OrderService.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+public class Order {
+    @Id
+    private UUID id;
+
+    private String status;
+
+    private Instant timestamp;
+}

--- a/src/main/java/ru/dadaev/OrderService/repository/OrderRepository.java
+++ b/src/main/java/ru/dadaev/OrderService/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package ru.dadaev.OrderService.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.dadaev.OrderService.domain.Order;
+
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+}

--- a/src/main/java/ru/dadaev/OrderService/service/OrderService.java
+++ b/src/main/java/ru/dadaev/OrderService/service/OrderService.java
@@ -1,0 +1,29 @@
+package ru.dadaev.OrderService.service;
+
+import org.springframework.stereotype.Service;
+import ru.dadaev.OrderService.domain.Order;
+import ru.dadaev.OrderService.dto.OrderRequestDto;
+import ru.dadaev.OrderService.dto.OrderResponseDto;
+import ru.dadaev.OrderService.repository.OrderRepository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+public class OrderService {
+    private final OrderRepository orderRepository;
+
+    public OrderService(OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    public OrderResponseDto createOrder(OrderRequestDto request) {
+        Order order = new Order();
+        order.setId(request.getId() != null ? request.getId() : UUID.randomUUID());
+        order.setStatus("accepted");
+        order.setTimestamp(Instant.now());
+
+        orderRepository.save(order);
+        return new OrderResponseDto(order.getStatus(), order.getId());
+    }
+}


### PR DESCRIPTION
## Summary
- add `Order` entity and JPA repository
- implement `OrderService` for order persistence
- update `OrderController` to delegate to the service

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_687b287eae70832d8a3f313c530deec6