### PR TITLE
Add MapStruct processor to maven compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                         </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.6.3</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- add `org.mapstruct:mapstruct-processor` as an annotation processor

## Testing
- `./mvnw --version` *(fails: cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687c72d51084832d906c8f0a5df770d6