### PR TITLE
Add Liquibase changelog split

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=OrderService

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: OrderService
+  datasource:
+    url: jdbc:postgresql://localhost:5432/mydatabase
+    username: myuser
+    password: secret
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.xml

--- a/src/main/resources/db/changelog/001-create-customer.xml
+++ b/src/main/resources/db/changelog/001-create-customer.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
+
+    <changeSet id="001-create-customer" author="codex">
+        <createTable tableName="customers">
+            <column name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="name" type="VARCHAR(255)" />
+            <column name="phone" type="VARCHAR(255)" />
+            <column name="address" type="VARCHAR(255)" />
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/002-create-order.xml
+++ b/src/main/resources/db/changelog/002-create-order.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
+
+    <changeSet id="002-create-order" author="codex">
+        <createTable tableName="orders">
+            <column name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="customer_id" type="BIGINT">
+                <constraints nullable="false" />
+            </column>
+            <column name="delivery_date" type="DATE" />
+            <column name="time_slot" type="VARCHAR(255)" />
+            <column name="additional_requirements" type="VARCHAR(255)" />
+            <column name="created_at" type="TIMESTAMP" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="orders"
+                                 baseColumnNames="customer_id"
+                                 referencedTableName="customers"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_orders_customer"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/003-create-order-items.xml
+++ b/src/main/resources/db/changelog/003-create-order-items.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
+
+    <changeSet id="003-create-order-items" author="codex">
+        <createTable tableName="order_items">
+            <column name="order_id" type="BIGINT">
+                <constraints nullable="false" />
+            </column>
+            <column name="product_id" type="BIGINT" />
+            <column name="requested_kg" type="DOUBLE PRECISION" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="order_items"
+                                 baseColumnNames="order_id"
+                                 referencedTableName="orders"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_order_items_order"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.22.xsd">
+
+    <include file="classpath:db/changelog/001-create-customer.xml"/>
+    <include file="classpath:db/changelog/002-create-order.xml"/>
+    <include file="classpath:db/changelog/003-create-order-items.xml"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Summary
- use separate Liquibase changelog files for customer, order, and order items tables
- include each changelog in db.changelog-master

## Testing
- `./mvnw -q test` *(fails to fetch apache-maven due to internet restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687c76b8cbdc832dbd5e16c531e4d3ce