### PR TITLE
Fix MapStruct mappings

### DIFF
--- a/src/main/java/ru/dadaev/OrderService/mapping/OrderMapper.java
+++ b/src/main/java/ru/dadaev/OrderService/mapping/OrderMapper.java
@@ -21,10 +21,17 @@ public interface OrderMapper {
     @Mapping(source = "timestamp", target = "createdAt")
     Order toEntity(OrderRequestDto dto);
 
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "name", source = "contactPerson")
+    @Mapping(target = "address", ignore = true)
+    @Mapping(target = "orders", ignore = true)
     Customer toEntity(CustomerDto dto);
 
+    @Mapping(target = "timeSlot", ignore = true)
     DeliveryInfo toEntity(DeliveryDto dto);
 
+    @Mapping(target = "productId", ignore = true)
+    @Mapping(target = "requestedKg", source = "quantityKg")
     OrderItem toEntity(ItemDto dto);
 }
 


### PR DESCRIPTION
## Summary
- implement missing mappings in `OrderMapper` to silence MapStruct compile errors

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687c870ae7f8832d9e7825bcb34ab6e7