### PR TITLE
Add Lombok MapStruct binding to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+            <optional>true</optional>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.mapstruct/mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>
@@ -95,6 +101,11 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
                         </path>
                         <path>
                             <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
## Summary
- add `lombok-mapstruct-binding` dependency
- configure annotation processors so Lombok processes before MapStruct

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_687cad67f47c832d85ccc3b330e5de44